### PR TITLE
feat: Implement markdown parser logic and add tests

### DIFF
--- a/nirman/parser.py
+++ b/nirman/parser.py
@@ -1,6 +1,59 @@
-def parse_markdown_tree(lines):
+# nirman/parser.py
+
+import re
+from typing import List, Tuple
+
+def parse_markdown_tree(lines: List[str]) -> List[Tuple[int, str, bool]]:
     """
-    Parses a list of lines from a Markdown file into a structured tree.
-    (To be implemented in Issue #3)
+    Parse a markdown tree structure into a list of tuples representing the file/folder hierarchy.
+    
+    Args:
+        lines: A list of strings, where each string is one line from the input Markdown file.
+        
+    Returns:
+        A list of tuples. Each tuple contains:
+        - depth (int): The level of the item in the tree
+        - name (str): The clean name of the file or folder
+        - is_directory (bool): True if it's a directory, False if it's a file
     """
-    pass
+    tree = []
+    
+    for line in lines:
+        line = line.rstrip()
+        if not line.strip():
+            continue
+
+        # Split the line to isolate the name from the tree symbols.
+        parts = re.split(r'--|──', line)
+        if len(parts) > 1:
+            name = parts[-1].strip()
+            # Find the position of the name to determine the prefix.
+            prefix_end_index = line.rfind(parts[-2]) + len(parts[-2])
+            prefix = line[:prefix_end_index]
+        else:
+            # This is the root item.
+            name = line.strip()
+            prefix = ""
+
+        # --- THIS IS THE FIX ---
+        # Calculate depth based on the visual indentation of the prefix.
+        # Each level of depth corresponds to 4 characters of indentation.
+        if not prefix:
+            depth = 0
+        else:
+            # The depth is the length of the prefix string divided by 4, plus one.
+            # Example: "│   " is length 4. (4 // 4) = 1.
+            # Example: "│       " is length 8. (8 // 4) = 2.
+            # We add 1 because the connector ('--') signifies the final step in depth.
+            depth = (len(prefix) // 4) + 1
+        
+        # Determine if it's a directory and clean the name.
+        is_directory = name.endswith(('\\', '/'))
+        clean_name = name.rstrip('\\/')
+
+        if clean_name == '.' and depth == 0:
+            is_directory = True
+
+        tree.append((depth, clean_name, is_directory))
+        
+    return tree

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,88 @@
+# tests/test_parser.py
+
+import pytest
+from nirman.parser import parse_markdown_tree
+
+# A standard Markdown tree for testing
+MARKDOWN_INPUT = [
+    "project-root/",
+    "├── src/",
+    "│   ├── main.py",
+    "│   └── utils/",
+    "│       └── helper.py",
+    "├── tests/",
+    "│   └── test_main.py",
+    "└── README.md",
+]
+
+# The expected output from the parser
+EXPECTED_OUTPUT = [
+    (0, "project-root", True),
+    (1, "src", True),
+    (2, "main.py", False),
+    (2, "utils", True),
+    (3, "helper.py", False),
+    (1, "tests", True),
+    (2, "test_main.py", False),
+    (1, "README.md", False),
+]
+
+def test_parse_standard_markdown_tree():
+    """
+    Tests that the parser correctly converts a standard Markdown tree.
+    """
+    parsed_tree = parse_markdown_tree(MARKDOWN_INPUT)
+    assert parsed_tree == EXPECTED_OUTPUT
+
+def test_parser_with_empty_lines():
+    """
+    Tests that the parser handles empty lines gracefully.
+    """
+    input_with_empty_lines = [
+        "project/",
+        "",
+        "├── file.txt",
+        "",
+    ]
+    expected = [
+        (0, "project", True),
+        (1, "file.txt", False),
+    ]
+    parsed_tree = parse_markdown_tree(input_with_empty_lines)
+    assert parsed_tree == expected
+
+def test_parser_root_is_dot():
+    """
+    Tests parsing when the root of the structure is '.'
+    """
+    input_data = [
+        ".",
+        "|-- main.py",
+        "|-- app/",
+        "|   |-- __init__.py"
+    ]
+    expected = [
+        (0, ".", True),
+        (1, "main.py", False),
+        (1, "app", True),
+        (2, "__init__.py", False)
+    ]
+    assert parse_markdown_tree(input_data) == expected
+
+def test_parser_alternative_syntax():
+    """
+    Tests parsing with alternative tree symbols ('|--') and dir separators ('\').
+    """
+    input_data = [
+        "app\\",
+        "|-- main.py",
+        "|-- services\\",
+        "|   |-- user_service.py"
+    ]
+    expected = [
+        (0, "app", True),
+        (1, "main.py", False),
+        (1, "services", True),
+        (2, "user_service.py", False)
+    ]
+    assert parse_markdown_tree(input_data) == expected


### PR DESCRIPTION
### Description

This PR implements the core logic for parsing the tree-style Markdown file. The `parse_markdown_tree` function in `nirman/parser.py` now correctly reads a list of lines and converts them into a structured format: `(depth, name, is_directory)`.

-   Handles both folder (`/`) and file entries.
-   Correctly calculates the depth of each entry based on indentation and tree symbols.
-   Ignores empty lines.

Unit tests have been added in `tests/test_parser.py` to validate the logic against standard and edge-case inputs.

### Related Issue

Closes #3 