### PR TITLE
feat: Implement file system builder logic

### DIFF
--- a/nirman/builder.py
+++ b/nirman/builder.py
@@ -1,6 +1,78 @@
-def build_structure(tree, output_path, dry_run=False, force=False):
+from pathlib import Path
+from typing import List, Tuple
+
+
+def build_structure(
+    tree: List[Tuple[int, str, bool]],
+    output_path: str,
+    dry_run: bool = False,
+    force: bool = False
+):
     """
-    Builds the directory and file structure from a parsed tree.
-    (To be implemented in a future issue)
+    Build a file/folder structure on disk from a parsed tree representation.
+    
+    Args:
+        tree: List of tuples (depth, name, is_directory) from parse_markdown_tree
+        output_path: The directory where the structure should be created
+        dry_run: If True, print actions without making changes
+        force: If True, overwrite existing files
     """
-    pass
+    # 1. Initialization
+    # Check if tree is empty
+    if not tree:
+        print("Empty tree provided. Nothing to create.")
+        return
+    
+    # Convert output_path to Path object
+    root_path = Path(output_path)
+    
+    # Initialize path stack with the root
+    path_stack = [root_path]
+    
+    # 2. Handle '.' root (Special Case)
+    has_dot_root = False
+    if tree and tree[0][1] == '.':
+        has_dot_root = True
+        tree = tree[1:]  # Remove the dot root
+        # Adjust depths of remaining items
+        tree = [(depth - 1, name, is_dir) for depth, name, is_dir in tree]
+    
+    # 3. Iterate Through the Tree
+    for depth, name, is_directory in tree:
+        # Skip literal '.' entries (don't create a './.' under output_path)
+        if name == '.':
+            continue
+        # Normalize negative depths and make parent selection defensive
+        depth = max(0, depth)
+        
+        # Reset path_stack to appropriate depth
+        path_stack = path_stack[: depth + 1]
+        # If depth exceeds current stack, use the last entry as parent
+        parent_index = depth if depth < len(path_stack) else (len(path_stack) - 1)
+        parent_path = path_stack[parent_index]
+        
+        # Calculate the current path
+        current_path = parent_path / name
+        
+        # 4. Process Directories
+        if is_directory:
+            print(f"Creating DIR: {current_path}")
+            
+            if not dry_run:
+                current_path.mkdir(parents=True, exist_ok=True)
+            
+            # Add the current directory to the stack
+            path_stack.append(current_path)
+        
+        # 5. Process Files
+        else:
+            # Print action; only modify filesystem when not a dry run
+            print(f"Creating FILE: {current_path}")
+            
+            if not dry_run:
+                # Ensure parent directory exists before creating the file
+                current_path.parent.mkdir(parents=True, exist_ok=True)
+                # Create or overwrite the file
+                if not current_path.exists() or force:
+                    current_path.write_text("")  # Replace touch() with write_text("")
+                    assert current_path.is_file()  # Verify file creation

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,68 @@
+import pytest
+from pathlib import Path
+from nirman.builder import build_structure
+
+# A sample parsed tree, like the output from your parser
+SAMPLE_TREE = [
+    (0, "project-root", True),
+    (1, "src", True),
+    (2, "main.py", False),
+    (1, "README.md", False),
+]
+
+def test_builder_creates_structure(tmp_path: Path):
+    """
+    Tests that the builder correctly creates folders and files.
+    """
+    build_structure(SAMPLE_TREE, output_path=str(tmp_path))
+
+    # Check that all paths were created correctly
+    assert (tmp_path / "project-root").is_dir()
+    assert (tmp_path / "project-root" / "src").is_dir()
+    assert (tmp_path / "project-root" / "src" / "main.py").is_file()
+    assert (tmp_path / "project-root" / "README.md").is_file()
+
+def test_builder_dry_run(tmp_path: Path):
+    """
+    Tests that dry_run prints actions but creates no files or folders.
+    """
+    build_structure(SAMPLE_TREE, output_path=str(tmp_path), dry_run=True)
+
+    # Check that nothing was created
+    # `iterdir()` returns a generator, we check if it's empty.
+    assert not any(tmp_path.iterdir())
+
+def test_builder_force_overwrite(tmp_path: Path):
+    """
+    Tests that the `force` flag correctly overwrites existing files.
+    """
+    # Create a pre-existing file with content
+    project_dir = tmp_path / "project-root"
+    project_dir.mkdir()
+    readme_file = project_dir / "README.md"
+    readme_file.write_text("Original content")
+
+    # Run build WITHOUT force - content should remain
+    build_structure(SAMPLE_TREE, output_path=str(tmp_path), force=False)
+    assert readme_file.read_text() == "Original content"
+
+    # Run build WITH force - content should be gone (file is truncated by touch())
+    build_structure(SAMPLE_TREE, output_path=str(tmp_path), force=True)
+    assert readme_file.read_text() == ""
+
+def test_builder_handles_dot_root(tmp_path: Path):
+    """
+    Tests that the builder works correctly when the parsed tree's root is '.'
+    """
+    tree_with_dot = [
+        (0, ".", True),
+        (1, "main.py", False),
+        (1, "app", True),
+    ]
+    build_structure(tree_with_dot, output_path=str(tmp_path))
+    
+    # The structure should be created directly inside tmp_path, not a '.' folder
+    assert (tmp_path / "main.py").is_file()
+    assert (tmp_path / "app").is_dir()
+    # Ensure no literal entry named '.' was created inside tmp_path
+    assert "." not in [p.name for p in tmp_path.iterdir()]


### PR DESCRIPTION
### Description

This PR implements the core logic for building the file and folder structure in `nirman/builder.py`.

-   Takes the parsed tree from the `parser` module as input.
-   Uses `pathlib` for cross-platform compatibility.
-   Correctly constructs the hierarchy based on the depth of each item.
-   Implements `--dry-run` to prevent any disk modifications.
-   Implements `--force` to allow overwriting of existing files.
-   Handles the special `.` root case gracefully.

Unit tests have been added in `tests/test_builder.py` using `pytest`'s `tmp_path` fixture to verify the builder's behavior in a temporary, safe environment.

### Related Issue

Closes #5 