### PR TITLE
feat: Implement CLI to coordinate parser and builder

### DIFF
--- a/nirman/cli.py
+++ b/nirman/cli.py
@@ -1,4 +1,71 @@
+import argparse
+import sys
+from pathlib import Path
+
+from .parser import parse_markdown_tree
+from .builder import build_structure
+
 def main():
-    """ The main entry point for the Nirman CLI."""
-    print("Nirman CLI is running!")
-    print("Next steps: Implement argument parsing and logic.")
+    """The main entry point for the Nirman CLI."""
+    parser = argparse.ArgumentParser(
+        description="Build a project structure from a Markdown tree file."
+    )
+
+    parser.add_argument(
+        "input_file",
+        type=str,
+        help="Path to the Markdown file containing the project structure."
+    )
+    parser.add_argument(
+        "-o", "--output",
+        default=".",
+        type=str,
+        help="Target directory where the structure will be created (default: current directory)."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the actions that would be taken without creating any files or directories."
+    )
+    parser.add_argument(
+        "-f", "--force",
+        action="store_true",
+        help="Overwrite existing files if they are encountered."
+    )
+
+    args = parser.parse_args()
+
+    # --- 1. Read the input file ---
+    input_path = Path(args.input_file)
+    if not input_path.is_file():
+        print(f"Error: Input file not found at '{input_path}'")
+        sys.exit(1)
+
+    try:
+        with open(input_path, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
+    except Exception as e:
+        print(f"Error: Could not read the input file: {e}")
+        sys.exit(1)
+        
+    # --- 2. Parse the structure ---
+    print("Parsing structure...")
+    parsed_tree = parse_markdown_tree(lines)
+    if not parsed_tree:
+        print("Warning: Parsed tree is empty. No structure to build.")
+        return
+
+    # --- 3. Build the file system ---
+    if args.dry_run:
+        print("\n--- Starting Dry Run (no changes will be made) ---")
+    else:
+        print(f"\n--- Building structure in '{Path(args.output).resolve()}' ---")
+    
+    build_structure(
+        tree=parsed_tree,
+        output_path=args.output,
+        dry_run=args.dry_run,
+        force=args.force
+    )
+    
+    print("\nNirman has finished.")

--- a/nirman/parser.py
+++ b/nirman/parser.py
@@ -1,5 +1,3 @@
-# nirman/parser.py
-
 import re
 from typing import List, Tuple
 
@@ -47,7 +45,6 @@ def parse_markdown_tree(lines: List[str]) -> List[Tuple[int, str, bool]]:
             # We add 1 because the connector ('--') signifies the final step in depth.
             depth = (len(prefix) // 4) + 1
         
-        # Determine if it's a directory and clean the name.
         is_directory = name.endswith(('\\', '/'))
         clean_name = name.rstrip('\\/')
 

--- a/structure.md
+++ b/structure.md
@@ -1,0 +1,11 @@
+project-root/
+├── src/
+│   ├── __init__.py
+│   ├── main.py
+│   └── utils/
+│       └── __init__.py
+├── tests/
+│   ├── __init__.py
+│   └── test_main.py
+├── .gitignore
+└── README.md


### PR DESCRIPTION
### Description

This PR implements the final piece of the MVP by wiring up the command-line interface in `nirman/cli.py`.

-   Uses `argparse` to handle the `input_file` argument and the `--output`, `--dry-run`, and `--force` options.
-   Reads the specified Markdown file.
-   Coordinates the workflow: `read file` -> `pass to parser` -> `pass parsed tree to builder`.
-   Includes error handling for a missing input file.
-   The `nirman` command is now fully functional.

This completes all core features planned for the initial version of the tool.

### Related Issue

Closes #7 