### PR TITLE
feat(30): add PyYAML runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ authors = [{ name="Hemanth Reddy Annem", email="Hemanthreddyannem@gmail.com" }]
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.7"
+dependencies = [
+    "PyYAML>=6.0",
+]
 keywords = ["cli", "scaffolding", "project-structure", "markdown"]
 
 classifiers = [


### PR DESCRIPTION
Adds PyYAML>=6.0 to runtime dependencies so YAML input support can be added later.

Closes #30 