### PR TITLE
feat(33): integrate YAML parser into CLI and add integration test

### DIFF
--- a/nirman/cli.py
+++ b/nirman/cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from .parser import parse_markdown_tree
 from .builder import build_structure
+from .yaml_parser import parse_yaml_tree
 
 def main():
     """The main entry point for the Nirman CLI."""
@@ -48,23 +49,23 @@ def main():
         print("Supported: .md, .markdown, .yml, .yaml")
         sys.exit(1)
 
-    if ext in {'.yml', '.yaml'}:
-        print(
-            f"YAML support is under development.\n"
-            f"The file '{input_path.name}' was detected as YAML, but parsing is not yet implemented."
-        )
-        sys.exit(0)
-
+    parsed_tree = None
     try:
-        with open(input_path, 'r', encoding='utf-8') as f:
-            lines = f.readlines()
+        if ext in {'.md', '.markdown'}:
+            # read lines (existing flow)
+            with open(input_path, 'r', encoding='utf-8') as f:
+                lines = f.readlines()
+            parsed_tree = parse_markdown_tree(lines)
+
+        elif ext in {'.yml', '.yaml'}:
+            # read whole YAML and parse to tree
+            with open(input_path, 'r', encoding='utf-8') as f:
+                yaml_text = f.read()
+            parsed_tree = parse_yaml_tree(yaml_text)
     except Exception as e:
-        print(f"Error: Could not read the input file: {e}")
+        print(f"Error: Failed to parse input file '{input_path}': {e}")
         sys.exit(1)
-        
-    # --- 2. Parse the structure ---
-    print("Parsing structure...")
-    parsed_tree = parse_markdown_tree(lines)
+
     if not parsed_tree:
         print("Warning: Parsed tree is empty. No structure to build.")
         return

--- a/tests/test_cli_yaml_integration.py
+++ b/tests/test_cli_yaml_integration.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+def test_cli_yaml_end_to_end(tmp_path, monkeypatch):
+    """
+    Integration test: create a YAML file, run the CLI, and verify files are created.
+    """
+    yaml_content = """
+project:
+  src:
+    - main.py
+    - utils:
+        - helper.py
+  files:
+    - README.md
+"""
+
+    input_file = tmp_path / "structure.yml"
+    input_file.write_text(yaml_content, encoding="utf-8")
+
+    output_dir = tmp_path / "out"
+
+    # Monkeypatch argv to simulate CLI call: program_name, input_file, -o, output_dir
+    monkeypatch.setattr(sys, "argv", ["nirman", str(input_file), "-o", str(output_dir)])
+
+    # Import and call CLI main
+    from nirman import cli
+    cli.main()
+
+    # Assertions: ensure structure exists
+    assert (output_dir / "project").is_dir()
+    assert (output_dir / "project" / "src").is_dir()
+    assert (output_dir / "project" / "src" / "main.py").is_file()
+    assert (output_dir / "project" / "src" / "utils").is_dir()
+    assert (output_dir / "project" / "src" / "utils" / "helper.py").is_file()
+    assert (output_dir / "project" / "README.md").is_file()


### PR DESCRIPTION
CLI now selects parser by file extension. YAML files are parsed using the new yaml_parser and built into the filesystem. Includes an end-to-end integration test.

Closes #33 