### PR TITLE
chore(36): bump version to 0.2.0 for YAML release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Nirman-cli"
-version = "0.1.9"
+version = "0.2.0"
 description = "A CLI tool to create project folder structures from a markdown file."
 authors = [{ name="Hemanth Reddy Annem", email="Hemanthreddyannem@gmail.com" }] 
 readme = "README.md"


### PR DESCRIPTION
Bumps version to 0.2.0 and prepares the package for PyPI release.

Closes #36 